### PR TITLE
ユーザー情報のアイコン画像の保存方法をURL→ファイル名に変更

### DIFF
--- a/components/common/Account.js
+++ b/components/common/Account.js
@@ -21,18 +21,14 @@ const doRegister = async (db, email, name) => {
   const initIntroduction = "自己紹介を入力してください！"
 
   // 初期の画像設定用urlの取得
-  const imageRef = firebase.storage().ref().child("suberoアプリロゴ.png")
-  let initImageUrl = ""
-  await imageRef.getDownloadURL().then((url) => {
-    initImageUrl = url
-  })
+  const initImageName = "initImage.png"
   // firestoreに登録
   await db
     .collection("users")
     .doc(email)
     .set(
       {
-        imageUrl: initImageUrl,
+        imageName: initImageName,
         profile: { name: name, introduction: initIntroduction }
       },
       { marge: true }
@@ -59,7 +55,7 @@ function Account(props) {
             login: true,
             userName: result.user.displayName,
             email: result.user.email,
-            imageUrl: ""
+            imageName: ""
           }
         })
         // 初回ログインかどうかの判断
@@ -88,7 +84,7 @@ function Account(props) {
         userName: "(click here!)",
         email: "",
         data: [],
-        imageUrl: ""
+        imageName: ""
       }
     })
     // this.props.onLogouted();

--- a/components/commonParts/getProfileImageUrl.js
+++ b/components/commonParts/getProfileImageUrl.js
@@ -1,0 +1,14 @@
+import "firebase/storage"
+import firebase from "../../redux/store"
+
+// storageのprofileImagesディレクトリの中の名前がfilenameのファイルのダウンロードURLを取得する関数
+const getProfileImageUrl = (filename) => {
+  return firebase
+    .storage()
+    .ref()
+    .child("profileImages")
+    .child(filename)
+    .getDownloadURL()
+}
+
+export default getProfileImageUrl

--- a/components/lessonadd/LessonAdd.js
+++ b/components/lessonadd/LessonAdd.js
@@ -5,6 +5,7 @@ import { connect } from "react-redux"
 import Lib from "../../Lib/address_lib"
 import Title from "../commonParts/Title"
 import InputForm from "./parts/InputForm"
+import getProfileImageUrl from "../commonParts/getProfileImageUrl"
 
 let imageUrl = ""
 
@@ -41,8 +42,8 @@ function LessonAdd(props) {
       .collection("users")
       .doc(email)
       .get()
-      .then(function (doc) {
-        imageUrl = doc.data().imageUrl
+      .then(async (doc) => {
+        imageUrl = await getProfileImageUrl(doc.data().imageName)
       })
   }
 

--- a/components/lessoninfo/LessonInfo.js
+++ b/components/lessoninfo/LessonInfo.js
@@ -7,6 +7,7 @@ import BuyBtn from "./parts/BuyBtn"
 import LessonDetail from "./parts/LessonDetail"
 import Title from "../commonParts/Title"
 import EditBtn from "./parts/EditBtn"
+import getProfileImageUrl from "../commonParts/getProfileImageUrl"
 
 let createrId = ""
 let createrName = ""
@@ -53,10 +54,10 @@ function LessonInfo(props) {
       .collection("users")
       .doc(createrId)
       .get()
-      .then((doc) => {
+      .then(async (doc) => {
         userData = doc.data()
         createrName = userData.profile.name
-        createrImageUrl = userData.imageUrl
+        createrImageUrl = await getProfileImageUrl(userData.imageName)
       })
 
     //購入したときに購入者の名前もfirebaseに書き込みたいから取得する

--- a/components/message/Message.js
+++ b/components/message/Message.js
@@ -10,6 +10,7 @@ import { connect } from "react-redux"
 import MessageAdd from "./MessageAdd"
 import Chat from "./parts/Chat"
 import Title from "../commonParts/Title"
+import getProfileImageUrl from "../commonParts/getProfileImageUrl"
 
 let createrId = ""
 let lessonName = ""
@@ -51,10 +52,10 @@ function Message(props) {
       .collection("users")
       .doc(createrId)
       .get()
-      .then((doc) => {
+      .then(async (doc) => {
         const createrData = doc.data()
         createrName = createrData.profile.name
-        createrImage = createrData.imageUrl
+        createrImage = await getProfileImageUrl(createrData.imageName)
       })
 
     //購入者の情報を取得
@@ -62,10 +63,10 @@ function Message(props) {
       .collection("users")
       .doc(buyerId)
       .get()
-      .then((doc) => {
+      .then(async (doc) => {
         const buyerData = doc.data()
         buyerName = buyerData.profile.name
-        buyerImage = buyerData.imageUrl
+        buyerImage = await getProfileImageUrl(buyerData.imageName)
       })
 
     // メッセージ情報の取得
@@ -99,7 +100,7 @@ function Message(props) {
           }
         })
       })
-      //ページが再レンダリングされる（新しいメッセージが画面に表示される）とそのページを開いている人のReadMessageをtrueにする
+    //ページが再レンダリングされる（新しいメッセージが画面に表示される）とそのページを開いている人のReadMessageをtrueにする
     if (email == createrId) {
       db.collection("messages").doc(messageId).set(
         {

--- a/components/mypage/MyProfile.js
+++ b/components/mypage/MyProfile.js
@@ -4,6 +4,7 @@ import "firebase/storage"
 import { connect } from "react-redux"
 import Lib from "../../Lib/address_lib"
 import MyProfileUi from "./parts/MyProfileUi"
+import getProfileImageUrl from "../commonParts/getProfileImageUrl"
 
 let name = "no data"
 let introduction = "no data"
@@ -21,12 +22,12 @@ function MyProfile(props) {
       .collection("users")
       .doc(email)
       .get()
-      .then((doc) => {
+      .then(async (doc) => {
         // 取得したデータを定数に入れてから、ステートに入れる
         const profileData = doc.data()
         name = profileData.profile.name
         introduction = profileData.profile.introduction
-        imageUrl = profileData.imageUrl
+        imageUrl = await getProfileImageUrl(profileData.imageName)
       })
     setUpdate(update ? false : true)
   }

--- a/components/profileShow/ProfileLessonList.js
+++ b/components/profileShow/ProfileLessonList.js
@@ -26,7 +26,7 @@ function ProfileLessonList(props) {
         .where("createrId", "==", router.query.userid)
         .orderBy("createdAt", "desc")
         .get()
-        .then(function (querySnapshot) {
+        .then((querySnapshot) => {
           querySnapshot.forEach((doc) => {
             lessonItems.push(
               <ProfileLesson

--- a/components/profileShow/ProfileShow.js
+++ b/components/profileShow/ProfileShow.js
@@ -4,6 +4,7 @@ import "firebase/storage"
 import { connect } from "react-redux"
 import ProfileShowUi from "./parts/ProFileShowUi"
 import { useRouter } from "next/router"
+import getProfileImageUrl from "../commonParts/getProfileImageUrl"
 
 let name = "no data"
 let introduction = "no data"
@@ -23,12 +24,12 @@ function ProfileShow(props) {
       .collection("users")
       .doc(router.query.userid)
       .get()
-      .then((doc) => {
+      .then(async (doc) => {
         // 取得したデータを定数に入れてから、ステートに入れる
         const profileData = doc.data()
         name = profileData.profile.name
         introduction = profileData.profile.introduction
-        imageUrl = profileData.imageUrl
+        imageUrl = await getProfileImageUrl(profileData.imageName)
       })
     setUpdate(update ? false : true)
   }


### PR DESCRIPTION
画像ファイルをアップロードしたときに名前が被っているとファイルが上書きされてしまう問題，アップロードされたファイルがストレージに残り続ける問題を解消しました．

画像の名前はいったん現在の時刻をファイル名の頭につける形で重複をなくしています．
その過程でファイルの削除の実装のためにusersコレクションのドキュメント内でのアイコン画像ファイルの保存方法をダウンロードURLの保存からファイル名の保存に変更しています．

どちらでも変わらないとおもったため，lessonsコレクションのcreaterImageUrlはそのままURLになっています．

この変更をマージした際は画像保存方法が未変更のアカウントの画像が表示されないため，再度アップロードもしくはアカウントの再登録をお願いします．